### PR TITLE
UI quality-of-life improvements

### DIFF
--- a/Source/GUIMissionProfileSelector.cs
+++ b/Source/GUIMissionProfileSelector.cs
@@ -12,7 +12,8 @@ namespace KSTS
         public const string SELECTED_DETAILS_PAYLOAD = "payload";
 
         private Vector2 scrollPos = Vector2.zero;
-        private int selectedIndex = -1;
+        private string nameSearch = "";
+        private bool hideInvalid = true;
         public MissionProfile selectedProfile = null;
 
         public double? filterMass = null;
@@ -26,15 +27,22 @@ namespace KSTS
         // Makes sure that the cached settings are still valid (eg if the player has deleted the selected profile):
         private void CheckInternals()
         {
-            // Recalculate the index because it might have changed (due to renaming)
-            selectedIndex = MissionController.missionProfiles.IndexOfValue(selectedProfile);
-
-            // IndexOfValue Returns -1 if the profile is null or not in the list
-            // invalidate the cached profile if this is the case
-            if (selectedIndex == -1)
+            if (!MissionController.missionProfiles.ContainsValue(selectedProfile))
             {
                 selectedProfile = null;
             }
+        }
+
+        // Whether this selector has any filters on valid profiles
+        private bool HasFilter()
+        {
+            return filterMass != null
+                || filterAltitude != null
+                || filterCrewCapacity != null
+                || filterRoundTrip != null
+                || filterDockingPortTypes != null
+                || filterBody != null
+                || filterMissionType != null;
         }
 
         // Displays the currently selected mission-profile and returns true, if the player has deselected the profile:
@@ -51,7 +59,6 @@ namespace KSTS
             if (GUILayout.Button("<size=14><color=#F9FA86><b>" + this.selectedProfile.profileName + "</b></color> ("+details+")</size>", new GUIStyle(GUI.buttonStyle) { alignment = TextAnchor.MiddleRight, stretchWidth = false, fixedWidth = 320 }))
             {
                 this.selectedProfile = null; // Back to the previous selection
-                this.selectedIndex = -1;
             }
             GUILayout.EndHorizontal();
             return this.selectedProfile == null;
@@ -61,7 +68,23 @@ namespace KSTS
         public bool DisplayList()
         {
             CheckInternals();
+
+            GUILayout.BeginHorizontal();
             GUILayout.Label("<size=14><b>Mission Profile:</b></size>");
+            GUILayout.FlexibleSpace();
+            GUILayout.Label("Filter:");
+            nameSearch = GUILayout.TextField(nameSearch, GUILayout.Width(200));
+            GUILayout.EndHorizontal();
+
+            // Only show the "Hide Invalid" checkbox if there are actually filters that make profiles invalid
+            if (this.HasFilter())
+            {
+                GUILayout.BeginHorizontal();
+                GUILayout.FlexibleSpace();
+                hideInvalid = GUILayout.Toggle(hideInvalid, "Hide Invalid");
+                GUILayout.EndHorizontal();
+            }
+
             scrollPos = GUILayout.BeginScrollView(scrollPos, GUI.scrollStyle);
             var green = "#00FF00";
             var red = "#FF0000";
@@ -74,9 +97,26 @@ namespace KSTS
             else
             {
                 var contents = new List<GUIContent>();
-                var invalidIndices = new List<int>(); // Profiles which fall out of the defined filters will get noted here.
+                var displayedProfiles = new List<MissionProfile>(); // The list of profiles which are actually displayed
+                var invalidIndices = new List<int>(); // Profiles which are not valid for the defined filters will get noted here.
+
+                // Filter out the profiles that should be hidden
+                // TODO - this can be cached so we don't have to search the list every frame
+                IEnumerable<MissionProfile> profiles = MissionController.missionProfiles.Values;
+                if (this.filterMissionType != null)
+                {
+                    // Always hide profiles that are not for the correct mission type, since there's no point in showing them
+                    profiles = profiles.Where(prof => prof.missionType == this.filterMissionType);
+                }
+                if (this.nameSearch != "")
+                {
+                    // Filter out profiles that don't match the name filter
+                    string f = nameSearch.ToLower();
+                    profiles = profiles.Where(prof => prof.vesselName.ToLower().Contains(f) || prof.profileName.ToLower().Contains(f));
+                }
+
                 var index = 0;
-                foreach (var missionProfile in MissionController.missionProfiles.Values)
+                foreach (var missionProfile in profiles)
                 {
                     var isValidProfile = true;
                     var color = "";
@@ -180,17 +220,24 @@ namespace KSTS
                     description += "<b>Crew-Capacity:</b> " + crewCapacity;
 
                     description += "</color>";
-                    contents.Add(new GUIContent(description, GUI.GetVesselThumbnail(missionProfile.vesselName)));
 
-                    if (!isValidProfile) invalidIndices.Add(index);
-                    index++;
+                    // Don't render invalid profiles if the "Hide Invalid" box is checked
+                    // Has to be done down here to avoid duplicating any logic
+                    if (isValidProfile || !hideInvalid)
+                    {
+                        displayedProfiles.Add(missionProfile);
+                        contents.Add(new GUIContent(description, GUI.GetVesselThumbnail(missionProfile.vesselName)));
+
+                        if (!isValidProfile) invalidIndices.Add(index);
+                        index++;
+                    }
                 }
 
-                var newSelection = GUILayout.SelectionGrid(selectedIndex, contents.ToArray(), 1, GUI.selectionGridStyle);
-                if (newSelection != selectedIndex && !invalidIndices.Contains(newSelection))
+                var prevSelection = displayedProfiles.IndexOf(this.selectedProfile);
+                var newSelection = GUILayout.SelectionGrid(prevSelection, contents.ToArray(), 1, GUI.selectionGridStyle);
+                if (newSelection != prevSelection && !invalidIndices.Contains(newSelection))
                 {
-                    selectedIndex = newSelection;
-                    selectedProfile = MissionController.missionProfiles.Values[selectedIndex];
+                    selectedProfile = displayedProfiles[newSelection];
                 }
             }
 

--- a/Source/GUIMissionProfileSelector.cs
+++ b/Source/GUIMissionProfileSelector.cs
@@ -123,7 +123,7 @@ namespace KSTS
 
                     // Build the descriptive text with highlighting:
                     var description = "<color=#F9FA86><b>" + missionProfile.profileName + "</b></color> <color=#FFFFFF>(" + missionProfile.vesselName + ")\n";
-                    description += "<b>Mass:</b> " + missionProfile.launchMass.ToString("0.0t") + ", Cost: " + missionProfile.launchCost.ToString("#,##0√") + ", ";
+                    description += "<b>Mass:</b> " + missionProfile.launchMass.ToString("0.0t") + ", <b>Cost:</b> <color=#B3D355>" + missionProfile.launchCost.ToString("#,##0√") + "</color>, ";
 
                     // One-Way or Round-Trip:
                     var missionRouteDetails = "";

--- a/Source/GUIMissionProfileSelector.cs
+++ b/Source/GUIMissionProfileSelector.cs
@@ -101,7 +101,6 @@ namespace KSTS
                 var invalidIndices = new List<int>(); // Profiles which are not valid for the defined filters will get noted here.
 
                 // Filter out the profiles that should be hidden
-                // TODO - this can be cached so we don't have to search the list every frame
                 IEnumerable<MissionProfile> profiles = MissionController.missionProfiles.Values;
                 if (this.filterMissionType != null)
                 {
@@ -110,7 +109,7 @@ namespace KSTS
                 }
                 if (this.nameSearch != "")
                 {
-                    // Filter out profiles that don't match the name filter
+                    // Filter out profiles that don't match the search box
                     string f = nameSearch.ToLower();
                     profiles = profiles.Where(prof => prof.vesselName.ToLower().Contains(f) || prof.profileName.ToLower().Contains(f));
                 }

--- a/Source/GUIMissionProfileSelector.cs
+++ b/Source/GUIMissionProfileSelector.cs
@@ -26,10 +26,14 @@ namespace KSTS
         // Makes sure that the cached settings are still valid (eg if the player has deleted the selected profile):
         private void CheckInternals()
         {
-            if (!MissionController.missionProfiles.Values.Contains(selectedProfile) || selectedIndex < 0 || selectedIndex >= MissionController.missionProfiles.Count)
+            // Recalculate the index because it might have changed (due to renaming)
+            selectedIndex = MissionController.missionProfiles.IndexOfValue(selectedProfile);
+
+            // IndexOfValue Returns -1 if the profile is null or not in the list
+            // invalidate the cached profile if this is the case
+            if (selectedIndex == -1)
             {
                 selectedProfile = null;
-                selectedIndex = -1;
             }
         }
 
@@ -186,7 +190,7 @@ namespace KSTS
                 if (newSelection != selectedIndex && !invalidIndices.Contains(newSelection))
                 {
                     selectedIndex = newSelection;
-                    selectedProfile = MissionController.missionProfiles.Values.ToList()[selectedIndex];
+                    selectedProfile = MissionController.missionProfiles.Values[selectedIndex];
                 }
             }
 

--- a/Source/GUIMissionProfileSelector.cs
+++ b/Source/GUIMissionProfileSelector.cs
@@ -123,7 +123,8 @@ namespace KSTS
 
                     // Build the descriptive text with highlighting:
                     var description = "<color=#F9FA86><b>" + missionProfile.profileName + "</b></color> <color=#FFFFFF>(" + missionProfile.vesselName + ")\n";
-                    description += "<b>Mass:</b> " + missionProfile.launchMass.ToString("0.0t") + ", <b>Cost:</b> <color=#B3D355>" + missionProfile.launchCost.ToString("#,##0√") + "</color>, ";
+                    description += "<b>Mass:</b> " + missionProfile.launchMass.ToString("0.0t") + ", <b>Cost:</b> <color=#B3D355>" + missionProfile.launchCost.ToString("#,##0√")
+                            + "</color> (<color=#B3D355>" + (missionProfile.launchCost / missionProfile.payloadMass).ToString("#,##0√") + "</color>/t), ";
 
                     // One-Way or Round-Trip:
                     var missionRouteDetails = "";

--- a/Source/GUIPayloadShipSelector.cs
+++ b/Source/GUIPayloadShipSelector.cs
@@ -72,7 +72,7 @@ namespace KSTS
             {
                 var ship = GUI.shipTemplates[i];
             
-                if (filter == "" || ship.template.shipName.Contains(filter))
+                if (filter == "" || ship.template.shipName.ToLower().Contains(filter.ToLower()))
                 {
                     bool b = false;
                     switch (ship.templateOrigin)

--- a/Source/MissionController.cs
+++ b/Source/MissionController.cs
@@ -704,7 +704,7 @@ namespace KSTS
 
     class MissionController
     {
-        public static Dictionary<string, MissionProfile> missionProfiles = null;
+        public static SortedList<string, MissionProfile> missionProfiles = null;
         public static List<Mission> missions = null;
 
         public static bool useKACifAvailable = true;
@@ -716,7 +716,7 @@ namespace KSTS
             if (MissionController.missionProfiles == null)
             {
                 Log.Warning("MissionController.Initialize");
-                MissionController.missionProfiles = new Dictionary<string, MissionProfile>();
+                MissionController.missionProfiles = new SortedList<string, MissionProfile>();
             }
 
             if (MissionController.missions == null)


### PR DESCRIPTION
Hi there!  I've been playing with this mod for a little while now, and I've had a few ides for quality-of-life improvements to the UI,  mostly centered around Mission Profile management.

I was in a coding mood today, so I decided to put all my ideas together and submit a pull request for them.  I've tested the changes locally and have confirmed that I can launch all the various mission types and rename/delete profiles without any issues.

Let me know if you've got any questions or if I should change anything!

### Full List of Changes

- The list of mission profiles highlights the cost in green, and also shows cost per ton (useful for construction missions)
![image](https://user-images.githubusercontent.com/6283552/186341316-353d0634-0e07-4504-9475-cd256d9b023e.png)

- The mission profile list is now sorted by name (and updates when profiles are renamed)
![image](https://user-images.githubusercontent.com/6283552/186341286-8cd6b9c3-5e59-4ac6-acff-cef481706e13.png)

- Transport profiles are no longer shown when picking a mission profile for a Deploy mission, and vice-versa
![image](https://user-images.githubusercontent.com/6283552/186341387-46efab36-d840-4e1c-b755-7d9766347dda.png)

- Profiles of the right type but not valid for a mission (e.g. because the payload is too heavy) are hidden by default, but can be shown with a checkbox
![image](https://user-images.githubusercontent.com/6283552/186341782-6128bd65-4f47-48c5-86aa-3d42128caa32.png)

- The list of profiles can be searched by name (either profile name or craft name)
![image](https://user-images.githubusercontent.com/6283552/186341676-3c8f4231-67c7-4b82-884b-b50ccc46d219.png)

- Both the payload search and profile search are now case-insensitive
![image](https://user-images.githubusercontent.com/6283552/186332287-7d8a4978-7277-4b71-85cc-439feee0234c.png)