### PR TITLE
Fix: Improved Staging on Deployed Vessels

### DIFF
--- a/Source/MissionController.cs
+++ b/Source/MissionController.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System.Text.RegularExpressions;
 using System.IO;
 using System.Linq;
-using KSP.UI.Screens.DebugToolbar.Screens.Cheats;
 using KSP.Localization;
+using KSP.UI.Screens;
 using static KSTS.Statics;
 using KSTS_KACWrapper;
 
@@ -546,6 +545,12 @@ namespace KSTS
                 AssembleForLaunchUnlanded(shipConstruct, crewToDeliver ?? Enumerable.Empty<string>(), duration, orbit, flagURL, game);
                 var newVessel = FlightGlobals.Vessels[FlightGlobals.Vessels.Count - 1];
                 newVessel.vesselName = shipName;
+                TrackedVessels.Add(newVessel.id);
+                if (!_addedEvent)
+                {
+                    GameEvents.onVesselLoaded.Add(CheckStaging);
+                    _addedEvent = true;
+                }
                 Log.Warning("deployed new ship '" + shipName + "' as '" + newVessel.protoVessel.vesselRef.id + "'");
                 ScreenMessages.PostScreenMessage("Vessel '" + shipName + "' deployed"); // Popup message to notify the player
 
@@ -556,6 +561,17 @@ namespace KSTS
             {
                 Debug.LogError("Mission.CreateShip(): " + e);
             }
+        }
+
+        private static readonly HashSet<Guid> TrackedVessels = new HashSet<Guid>();
+
+        private static bool _addedEvent;
+
+        public void CheckStaging(Vessel vessel)
+        {
+            if (!TrackedVessels.Contains(vessel.id)) return;
+            StageManager.BeginFlight();
+            TrackedVessels.Remove(vessel.id);
         }
 
         // Generates a description for displaying on the GUI:


### PR DESCRIPTION
### Overview
This pull request introduces improvements to the staging process for vessels deployed using KSTS. The primary adjustment is the invocation of `StageManager.BeginFlight()` when a KSTS-deployed vessel is loaded. While there are undoubtedly better methods to achieve this, the current solution works without requiring refactoring.

### Known Issue
There is an outstanding issue where staging fails to function correctly if a player deploys a vessel and exits the game before actually loading into that vessel. When the game is relaunched and the vessel finally loaded, the staging is all on a single stage. I don't see a way around this without storing information about KSTS-deployed vessels in the save file or elsewhere on disk.